### PR TITLE
Svp/emissive surfaces fix

### DIFF
--- a/gamedata/shaders/r3/scope_common.h
+++ b/gamedata/shaders/r3/scope_common.h
@@ -72,6 +72,9 @@ int scope_debug;
 
 uniform int scope_svp;
 float isSVPActive() { return scope_svp; }
+float isSVPFrame() { return m_hud_params.w > 0.5; }
+
+#define SCOPE_TO_FRAMEBUFFER_RATIO (isSVPFrame() ? 2.0 : 1.0)
 
 
 float zoomRotateFactor() { return m_hud_params.x; }

--- a/src/Layers/xrRender/r__dsgraph_render.cpp
+++ b/src/Layers/xrRender/r__dsgraph_render.cpp
@@ -747,8 +747,6 @@ void R_dsgraph_structure::r_dsgraph_render_emissive(bool clear, bool renderHUD)
 #if	RENDER!=R_R1
 	// Sorted (back to front)
 	mapEmissive.traverseLR(sorted_L1);
-	if (clear)
-		mapEmissive.clear();
 
 	// Change projection
 	Fmatrix FTold = Device.mFullTransform;
@@ -761,9 +759,6 @@ void R_dsgraph_structure::r_dsgraph_render_emissive(bool clear, bool renderHUD)
 	// Sorted (back to front)
 	mapHUDEmissive.traverseLR(sorted_L1);
 	
-	if (clear)
-		mapHUDEmissive.clear();
-
 	if (renderHUD)
 		mapHUDSorted.traverseRL(sorted_L1);
 

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -609,6 +609,13 @@ void CRender::renderGBuffer() {
 
 void CRender::combineLightingAndBloom()
 {
+	// FIXME: SVP: Hack to force SRVSManager to unbind the first slot.
+	//  Required until more robust state invalidation is in place.
+	auto unbind_s_base = []() -> void {
+		ID3D11ShaderResourceView* crv[1] = {nullptr};
+		HW.pContext->PSSetShaderResources(0, 1, crv);
+	};
+
 	{
 		PIX_EVENT(DEFER_SELF_ILLUM);
 		Target->phase_accumulator();
@@ -625,6 +632,9 @@ void CRender::combineLightingAndBloom()
 		//RCache.set_Stencil				(TRUE,D3DCMP_ALWAYS,0x00,0xff,0xff,D3DSTENCILOP_KEEP,D3DSTENCILOP_REPLACE,D3DSTENCILOP_KEEP);
 		RCache.set_CullMode(CULL_CCW);
 		RCache.set_ColorWriteEnable();
+
+		unbind_s_base();
+
 		RImplementation.r_dsgraph_render_emissive(RImplementation.o.ssfx_bloom ? false : true);
 	}
 
@@ -634,6 +644,9 @@ void CRender::combineLightingAndBloom()
 		FLOAT ColorRGBA[4] = { 0,0,0,0 };
 		HW.pContext->ClearRenderTargetView(Target->rt_ssfx_bloom_emissive->pRT, ColorRGBA);
 		Target->u_setrt(Target->rt_ssfx_bloom_emissive, NULL, NULL, !RImplementation.o.dx10_msaa ? Target->baseZB : Target->rt_MSAADepth->pZRT);
+
+		unbind_s_base();
+
 		RImplementation.r_dsgraph_render_emissive(true, true);
 	}
 }
@@ -751,6 +764,9 @@ void CRender::Render()
 
 	// Clear the stored lenses
 	RImplementation.mapScopeHUDSorted.clear();
+	mapEmissive.clear();
+	mapHUDEmissive.clear();
+
 	Device.m_SecondViewport.eyepiece.radius = 0;
 	Device.m_SecondViewport.objective.radius = 0;
 


### PR DESCRIPTION
<img width="652" height="498" alt="self-illum-failed-invalidation" src="https://github.com/user-attachments/assets/669b3577-5b5d-41b7-8708-c6f6fa793b29" />

- retain render list for emissive in SVP view
- Force invalidation of s_base, to prevent emissive surfaces being erroneously sent smap textures (Fixes red hue)