### PR TITLE
Svp/safer texture substitution

### DIFF
--- a/src/Layers/xrRender/R_Backend.h
+++ b/src/Layers/xrRender/R_Backend.h
@@ -145,6 +145,7 @@ private:
 	ID3D11HullShader* hs;
 	ID3D11DomainShader* ds;
 	ID3D11ComputeShader* cs;
+	xr_map<shared_str, ref_texture> textureOverrides;
 #	endif
 #endif	//	USE_DX10
 
@@ -271,6 +272,10 @@ public:
 
 	IC void set_Constants(R_constant_table* C);
 	IC void set_Constants(ref_ctable& C) { set_Constants(&*C); }
+
+#if defined(USE_DX11)
+	void override_Texture(shared_str name, ref_texture texture);
+#endif
 
 	void set_Textures(STextureList* T);
 	IC void set_Textures(ref_texture_list& T) { set_Textures(&*T); }

--- a/src/Layers/xrRender/R_Backend_Runtime.cpp
+++ b/src/Layers/xrRender/R_Backend_Runtime.cpp
@@ -149,6 +149,8 @@ void CBackend::Invalidate()
 	for (u32 hs_it = 0; hs_it < mtMaxHullShaderTextures;) textures_hs[hs_it++] = 0;
 	for (u32 ds_it = 0; ds_it < mtMaxDomainShaderTextures;) textures_ds[ds_it++] = 0;
 	for (u32 cs_it = 0; cs_it < mtMaxComputeShaderTextures;) textures_cs[cs_it++] = 0;
+
+	textureOverrides.clear();
 #endif
 #endif	//	USE_DX10
 
@@ -217,6 +219,13 @@ void CBackend::set_ClipPlanes(u32 _enable, Fmatrix* _xform /*=NULL */, u32 fmask
 	set_ClipPlanes(_enable, F.planes, F.p_count);
 }
 
+#if defined(USE_DX11)
+void CBackend::override_Texture(shared_str name, ref_texture texture) {
+	textureOverrides[name] = texture;
+	T = NULL; // Make sure to clear the current cached textures to force a rebind
+}
+#endif
+
 void CBackend::set_Textures(STextureList* _T)
 {
 	if (T == _T) return;
@@ -240,6 +249,10 @@ void CBackend::set_Textures(STextureList* _T)
 		std::pair<u32, ref_texture>& loader = *_it;
 		u32 load_id = loader.first;
 		CTexture* load_surf = &*loader.second;
+#if defined(USE_DX11) 
+		if (nullptr != load_surf && textureOverrides.count(load_surf->cName))
+			load_surf = textureOverrides[load_surf->cName]._get();
+#endif
 
 		//		if (load_id < 256)		{
 		if (load_id < CTexture::rstVertex)

--- a/src/Layers/xrRender/SH_Texture.h
+++ b/src/Layers/xrRender/SH_Texture.h
@@ -38,7 +38,6 @@ public:
 	//	void								Apply			(u32 dwStage);
 
 	void surface_set(ID3DBaseTexture* surf);
-	void fast_set_unsafe(CTexture* source);
 	ID3DBaseTexture* surface_get();
 
 	IC BOOL isUser() { return flags.bUser; }

--- a/src/Layers/xrRender/rendertarget_phase_nightvision.cpp
+++ b/src/Layers/xrRender/rendertarget_phase_nightvision.cpp
@@ -399,25 +399,18 @@ void CRenderTarget::phase_3DSSReticle()
 	}
 
 	{   // Remap gbuffer bindings to where the scope was rendered
-		ref_texture secondVP;
-		secondVP.create(r2_RT_secondVP);
-		secondVP->fast_set_unsafe(Device.m_SecondViewport.IsSVPActive() 
-			? RImplementation.TargetSVP->rt_secondVP->pTexture._get() 
-			: rt_secondVP->pTexture._get());
+		auto f = [&](LPCSTR name, ref_rt& target) -> void {
+			ref_texture t;
+			t.create(name);
+			RCache.override_Texture(t->cName, target->pTexture);
+		};
 
-		ref_texture rt_pos_tmp;
-		rt_pos_tmp.create(r2_RT_generic2);
-		rt_pos_tmp->fast_set_unsafe(Device.m_SecondViewport.IsSVPActive() 
-			? RImplementation.TargetSVP->rt_Position->pTexture._get() 
-			: rt_Generic_2->pTexture._get());
+		auto svp = Device.m_SecondViewport.IsSVPActive();
+		
+		f(r2_RT_secondVP, svp ? RImplementation.TargetSVP->rt_secondVP : RImplementation.TargetMain->rt_secondVP);		
+		f(r2_RT_generic2, svp ? RImplementation.TargetSVP->rt_Position : RImplementation.TargetMain->rt_Generic_2);
+		f(r2_RT_heat,     svp ? RImplementation.TargetSVP->rt_Heat : RImplementation.TargetMain->rt_Heat);
 
-		ref_texture rt_heat_tmp;
-		rt_heat_tmp.create(r2_RT_heat);
-		rt_heat_tmp->fast_set_unsafe(Device.m_SecondViewport.IsSVPActive() 
-			? RImplementation.TargetSVP->rt_Heat->pTexture._get() 
-			: rt_Heat->pTexture._get());
-
-		RCache.Invalidate();
 		u_setrt(RImplementation.TargetMain->rt_Generic_0, nullptr, RImplementation.TargetMain->rt_Position, RImplementation.TargetMain->baseZB);
 	}
 

--- a/src/Layers/xrRenderDX10/dx10SH_Texture.cpp
+++ b/src/Layers/xrRenderDX10/dx10SH_Texture.cpp
@@ -52,20 +52,6 @@ CTexture::~CTexture()
 	DEV->_DeleteTexture(this);
 }
 
-void CTexture::fast_set_unsafe(CTexture* source) {
-	if (!source) return;
-
-	if (!unsafe_set) {
-		_RELEASE(m_pSRView);
-		_RELEASE(pSurface);
-		unsafe_set = true;
-	}
-
-	m_pSRView = source->m_pSRView;
-	pSurface = source->pSurface;
-	desc_cache = source->desc_cache;
-}
-
 void CTexture::surface_set(ID3DBaseTexture* surf)
 {
 	if (surf) surf->AddRef();

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -697,6 +697,8 @@ void CRender::Render()
 
 	rmNormal();
 
+	TargetMain->SetActive();
+
 	bool _menu_pp = g_pGamePersistent ? g_pGamePersistent->OnRenderPPUI_query() : false;
 	if (_menu_pp)
 	{

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget.cpp
@@ -359,8 +359,12 @@ void CRenderTarget::SetActive(bool force) {
 	HW.pBaseRT = baseRT;
 	HW.pBaseZB = baseZB;
 
-	if (!force && RImplementation.Target == this)
+	if (!force && RImplementation.Target == this) {
+		for (auto rt : RenderTargetRemaps) {
+			RCache.override_Texture(rt.first->cName, rt.second->pTexture);
+		}
 		return;
+	}
 
 	auto m = Device.matrices[isMain ? 0 : 1];
 	if (g_pGamePersistent) {
@@ -370,9 +374,7 @@ void CRenderTarget::SetActive(bool force) {
 	}
 	RImplementation.Target = this;
 
-	for (auto rt : RenderTargetRemaps) {
-		rt.first->fast_set_unsafe(rt.second->pTexture._get());
-	}
+
 
 	RImplementation.ViewBase.CreateFromMatrix(Device.mFullTransform, FRUSTUM_P_LRTB + FRUSTUM_P_FAR);
 	RImplementation.View = 0;
@@ -385,6 +387,11 @@ void CRenderTarget::SetActive(bool force) {
 	Device.fHeight_2 = Height >> 1;
 	
 	RCache.Invalidate();
+
+	for (auto rt : RenderTargetRemaps) {
+		RCache.override_Texture(rt.first->cName, rt.second->pTexture);
+	}
+
 	set_viewport_size(HW.pContext, custom_viewport->Width, custom_viewport->Height);
 	RCache.set_RT(baseRT, 0);
 	RCache.set_RT(nullptr, 1);


### PR DESCRIPTION
fast_set_unsafe often leads to framebuffer corruption, so swap the texture reference at shader resource bind point instead.

Note that RT textures are no longer swapped, and must be referenced explicitly: (`TargetMain` no longer points to `TargetSVP` in a `SVPFrame`)